### PR TITLE
Fix autodoc deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MailingListParser
+# Mailing List Network Analyzer
 
 [![Build Status](https://travis-ci.org/prasadtalasila/MailingListParser.svg?branch=development)](https://travis-ci.org/prasadtalasila/MailingListParser) 
 [![Code Climate](https://codeclimate.com/github/prasadtalasila/MailingListParser/badges/gpa.svg)](https://codeclimate.com/github/prasadtalasila/MailingListParser) 

--- a/etc/deploy_docs.sh
+++ b/etc/deploy_docs.sh
@@ -9,7 +9,7 @@
 
 set -e # Exit with nonzero exit code if anything fails
 
-SOURCE_BRANCH1="master"
+SOURCE_BRANCH1="development"
 TARGET_BRANCH="gh-pages"
 ENCRYPTION_LABEL="fafbdc041e4b"
 COMMIT_AUTHOR_EMAIL="achyudhk@gmail.com"
@@ -20,7 +20,7 @@ function createDocs {
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH"]; then
     echo "Skipping deploy; just doing a build."
     exit 0
 fi
@@ -47,6 +47,11 @@ createDocs
 cd out
 git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
+
+if [ -z `git diff --exit-code` ]; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+fi
 
 # Commit the "changes", i.e. the new version.
 # The delta will show diffs between new and old versions.


### PR DESCRIPTION
# Fix autodoc deploy script
Fix  issue 73
Changes proposed in this pull request:
Prevent deploy of no changes
Restrict autodoc to development

## Checks
- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure you have added required documentation
- [ ] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@achyudhk
