### PR TITLE
Added some pip installs in requirements.txt and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Presently, MailingListParser has various end-to-end tests implemented which resi
 
 ## Installation
 
-MailingListParser depends on various third-party libraries which are listed in [requirements.txt](https://github.com/prasadtalasila/MailingListParser/blob/development/requirements.txt).
-Run `pip3 install -r requirements.txt` in the project root directory to install these dependencies.
+MailingListParser depends on various third-party libraries which are listed in [requirements.txt](https://github.com/prasadtalasila/MailingListParser/blob/development/etc/requirements.txt).
+The libraries in `requirements.txt` along with other dependencies are installed using [install_package_dependencies.sh](https://github.com/prasadtalasila/MailingListParser/blob/development/etc/install_package_dependencies.sh) 
+Run `cd etc && bash install_package_dependencies.sh` in the project root directory to install these dependencies.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Presently, MailingListParser has various end-to-end tests implemented which resi
 
 ## Installation
 
-MailingListParser depends on various third-party libraries which are listed in [requirements.txt](https://github.com/prasadtalasila/MailingListParser/blob/development/etc/requirements.txt).
+MailingListParser depends on various third-party libraries which are listed in [requirements.txt](https://github.com/prasadtalasila/MailingListParser/blob/development/requirements.txt).
 The libraries in `requirements.txt` along with other dependencies are installed using [install_package_dependencies.sh](https://github.com/prasadtalasila/MailingListParser/blob/development/etc/install_package_dependencies.sh) 
 Run `cd etc && bash install_package_dependencies.sh` in the project root directory to install these dependencies.
 

--- a/etc/install_package_dependencies.sh
+++ b/etc/install_package_dependencies.sh
@@ -54,4 +54,5 @@ sudo apt-get install -y libxml2-dev libigraph0-dev
 
 # Install python packages
 cd "$PROJECT_PATH"
+cd ..
 sudo -H pip3 install -r requirements.txt

--- a/etc/install_package_dependencies.sh
+++ b/etc/install_package_dependencies.sh
@@ -35,9 +35,6 @@ sudo apt-get install -y --allow-unauthenticated python3-graph-tool
 pip3 install --upgrade pip
 sudo -H pip3 install --upgrade pip
 
-# Install NetworkX
-sudo -H pip3 install networkx==1.11
-
 # Install Infomap Community Detection
 sudo apt-get install -y swig
 mkdir Infomap
@@ -49,12 +46,11 @@ cd examples/python
 make python3
 python3 example-networkx.py
 
-# Install PyGraphViz
-sudo -H pip3 install pygraphviz
+# For installation(pip) of PyGraphViz
+sudo apt-get install graphviz libgraphviz-dev pkg-config
 
-# Install Python-iGraph
-sudo apt-get install -y libxml2-dev
-sudo -H pip3 install python-igraph
+# For installation(pip) Python-iGraph
+sudo apt-get install -y libxml2-dev libigraph0-dev
 
 # Install python packages
 cd "$PROJECT_PATH"

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -9,3 +9,5 @@ networkx==1.11
 pytest>=3.0.5
 sphinx>=1.4.1
 plotly>=1.3.2
+python-igraph
+pygraphviz

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ networkx==1.11
 pytest>=3.0.5
 sphinx>=1.4.1
 plotly>=1.3.2
-python-igraph
-pygraphviz
+python-igraph>=0.7.0
+pygraphviz>=1.3.1


### PR DESCRIPTION
Moved the following pip install from `install_package_dependencies.sh` to `requirements.txt`:
1. pygraphviz
2. python-igraph

Removed networkx from `install_package_dependencies.sh` as it was already there in `requirements.txt`.

Moved the `requirements.txt` file to etc/ directory in the project for convenience as `install_package_dependencies.sh` is using it.

Updated the README.md considering all the above changes.

Also, `cd etc && bash install_package_dependencies.sh` is given a run and it works fine, other than when building the Infomap/ directory in etc/, we encounter some warnings related to pointers.

@achyudhk 
@prasadtalasila 
@yashpungaliya 
